### PR TITLE
typescript generics POC

### DIFF
--- a/packages/ui-form/src/controller/App.controller.ts
+++ b/packages/ui-form/src/controller/App.controller.ts
@@ -8,7 +8,7 @@ export default class AppController extends Controller {
 
 	public onInit() {
 		// apply content density mode to root view
-		this.getView().addStyleClass((this.getOwnerComponent() as AppComponent).getContentDensityClass());
+		this.getView().addStyleClass(this.getOwnerComponent<AppComponent>().getContentDensityClass());
 	};
 
 };

--- a/packages/ui-form/src/controller/Registration.controller.ts
+++ b/packages/ui-form/src/controller/Registration.controller.ts
@@ -46,7 +46,7 @@ export default class RegistrationController extends Controller {
 	public onInit() {
 
 		// keep the reference to the OData model
-		this.oDataModel = this.getOwnerComponent().getModel() as ODataModel;
+		this.oDataModel = this.getOwnerComponent().getModel<ODataModel>();
 
 		// load previous data
 		const oBinding = this.oDataModel.bindList("/Person");
@@ -62,7 +62,7 @@ export default class RegistrationController extends Controller {
 		});
 
 		// store the reference to the i18n model
-		this.oBundle = (this.getOwnerComponent().getModel("i18n") as ResourceModel).getResourceBundle() as ResourceBundle;
+		this.oBundle = this.getOwnerComponent().getModel<ResourceModel>("i18n").getResourceBundle() as ResourceBundle;
 
 		// listen to focusleave on the fields to validate the user input
 		const aControls = Core.byFieldGroupId("RegForm");
@@ -77,7 +77,7 @@ export default class RegistrationController extends Controller {
 		this.getView().addEventDelegate({
 			onAfterShow: () => {
 				this.byId("firstName").focus();
-				(this.byId("page") as Page).scrollTo(0);
+				this.byId<Page>("page").scrollTo(0);
 			}
 		})
 
@@ -141,7 +141,7 @@ export default class RegistrationController extends Controller {
 				MessageToast.show(this.oBundle.getText("existingDraftLoaded"), {duration: 5000});
 			}
 
-			(this.byId("submitButton") as Button).setText(this.oBundle.getText("updateButtonText"));
+			this.byId<Button>("submitButton").setText(this.oBundle.getText("updateButtonText"));
 		}
 	};
 
@@ -150,12 +150,12 @@ export default class RegistrationController extends Controller {
 	};
 
 	public addFamilyMember() {
-		const oListBinding = this.byId("familyMembersTable").getBinding("items") as ODataListBinding;
+		const oListBinding = this.byId("familyMembersTable").getBinding<ODataListBinding>("items");
 		oListBinding.create({});
 	};
 
 	public deleteFamilyMember(oEvent: UI5Event) {
-		((oEvent.getSource() as Control).getBindingContext() as V4Context).delete("$auto").then(() => {
+		oEvent.getSource<Control>().getBindingContext<V4Context>().delete("$auto").then(() => {
 			// deletion success
 		}, (oError: Error) => {
 			// TODO: ignore deletion failure?
@@ -175,15 +175,15 @@ export default class RegistrationController extends Controller {
 	};
 
 	public validateData() {
-		const oNewObject = this.getView().getBindingContext().getObject() as Employee;
+		const oNewObject = this.getView().getBindingContext().getObject<Employee>();
 
 		// determine field names for validation dialog
 		const oBundle = this.oBundle;
-		const mFields = {
+		const mFields: Person = {
 			LastName: oBundle.getText("name"),
 			FirstName: oBundle.getText("firstName"),
 			Birthday: oBundle.getText("dateOfBirth")
-		} as Person;
+		};
 
 		// check for missing fields
 		const aMissing = [];
@@ -225,7 +225,7 @@ export default class RegistrationController extends Controller {
 			return;
 		}
 
-		const oContext = this.getView().getBindingContext() as V4Context;
+		const oContext = this.getView().getBindingContext<V4Context>();
 
 		/* omit this block as failing "draftActivate" is not expected (no data checks in backend) aand a failing PATCH would not be dramatic
 		// ensure there are no pending changes (because otherwise with a failing "save" the last PATCH which might be in the same batch would also fail)
@@ -235,7 +235,7 @@ export default class RegistrationController extends Controller {
 		*/
 
 		// submit the person data
-		(this.byId("submitButton") as Button).setEnabled(false);
+		this.byId<Button>("submitButton").setEnabled(false);
 
 		// trigger OData operation for persisting the draft as real data
 
@@ -246,7 +246,7 @@ export default class RegistrationController extends Controller {
 		oOperation.execute()
 		.then(() => {
 			// navigate without hash change
-			(this.getOwnerComponent() as UIComponent).getRouter().getTargets().display("confirmation");
+			this.getOwnerComponent<UIComponent>().getRouter().getTargets().display("confirmation");
 		})
 		.catch((err: Error) => {
 			this.showErrorDialog()
@@ -256,7 +256,7 @@ export default class RegistrationController extends Controller {
 	public showErrorDialog() {
 		const sText = this.oBundle.getText("submitErrorText");
 		const sTitle = this.oBundle.getText("submitErrorTitle");
-		(this.byId("submitButton") as Button).setEnabled(true);
+		this.byId<Button>("submitButton").setEnabled(true);
 		MessageBox.error(sText, {
 			title: sTitle
 		});

--- a/packages/ui-form/types/sap.ui.core.d.ts
+++ b/packages/ui-form/types/sap.ui.core.d.ts
@@ -6125,7 +6125,7 @@ declare module "sap/ui/base/Event" {
     /**
      * Returns the event provider on which the event was fired.
      */
-    getSource(): EventProvider;
+    getSource<T = EventProvider>(): T;
     /**
      * Prevent the default action of this event.
      *
@@ -7876,12 +7876,12 @@ declare module "sap/ui/base/ManagedObject" {
     /**
      * Get the binding object for a specific aggregation/property
      */
-    getBinding(
+    getBinding<T = Binding>(
       /**
        * the name of the property or aggregation
        */
       sName: string
-    ): Binding;
+    ): T;
     /**
      * Get the binding context of this object for the given model name.
      *
@@ -7897,12 +7897,12 @@ declare module "sap/ui/base/ManagedObject" {
      *
      * **Note:** A ManagedObject inherits binding contexts from the Core only when it is a descendant of a UIArea.
      */
-    getBindingContext(
+    getBindingContext<T = Context>(
       /**
        * the name of the model or `undefined`
        */
       sModelName?: string
-    ): Context;
+    ): T;
     /**
      * Returns the binding info for the given property or aggregation.
      *
@@ -7965,12 +7965,12 @@ declare module "sap/ui/base/ManagedObject" {
      * 	 - string literals `"null"` or `"undefined"`  Omitting the model name (or using the value `undefined`)
      * 			is explicitly allowed and refers to the default model.
      */
-    getModel(
+    getModel<T = Model>(
       /**
        * name of the model to be retrieved
        */
       sModelName?: string | undefined
-    ): Model;
+    ): T;
     /**
      * Get the object binding object for a specific model.
      *
@@ -25625,12 +25625,12 @@ declare module "sap/ui/core/mvc/Controller" {
      * If no view is connected or if the view doesn't contain an element with the given local ID, undefined
      * is returned.
      */
-    byId(
+    byId<T = UI5Element>(
       /**
        * View-local ID
        */
       sId: string
-    ): UI5Element;
+    ): T;
     /**
      * @SINCE 1.56.0
      *
@@ -25692,7 +25692,7 @@ declare module "sap/ui/core/mvc/Controller" {
      * If there is no Component connected to the view or the view is not connected to the controller, undefined
      * is returned.
      */
-    getOwnerComponent(): Component;
+    getOwnerComponent<T = Component>(): T;
     /**
      * Returns the view associated with this controller or undefined.
      */
@@ -41851,7 +41851,7 @@ declare module "sap/ui/model/Context" {
      * Gets the (model dependent) object the context points to or the object with the given relative binding
      * path
      */
-    getObject(
+    getObject<T = object>(
       /**
        * the binding path
        */
@@ -41860,7 +41860,7 @@ declare module "sap/ui/model/Context" {
        * additional model specific parameters (optional)
        */
       mParameters?: object
-    ): object;
+    ): T;
     /**
      * Getter for path of the context itself or a subpath
      */

--- a/packages/ui-form/types/sap.ui.core.d.ts
+++ b/packages/ui-form/types/sap.ui.core.d.ts
@@ -6125,7 +6125,7 @@ declare module "sap/ui/base/Event" {
     /**
      * Returns the event provider on which the event was fired.
      */
-    getSource<T = EventProvider>(): T;
+    getSource<T extends EventProvider = EventProvider>(): T;
     /**
      * Prevent the default action of this event.
      *
@@ -7876,7 +7876,7 @@ declare module "sap/ui/base/ManagedObject" {
     /**
      * Get the binding object for a specific aggregation/property
      */
-    getBinding<T = Binding>(
+    getBinding<T extends Binding = Binding>(
       /**
        * the name of the property or aggregation
        */
@@ -7897,7 +7897,7 @@ declare module "sap/ui/base/ManagedObject" {
      *
      * **Note:** A ManagedObject inherits binding contexts from the Core only when it is a descendant of a UIArea.
      */
-    getBindingContext<T = Context>(
+    getBindingContext<T extends Context = Context>(
       /**
        * the name of the model or `undefined`
        */
@@ -7965,7 +7965,7 @@ declare module "sap/ui/base/ManagedObject" {
      * 	 - string literals `"null"` or `"undefined"`  Omitting the model name (or using the value `undefined`)
      * 			is explicitly allowed and refers to the default model.
      */
-    getModel<T = Model>(
+    getModel<T extends Model = Model>(
       /**
        * name of the model to be retrieved
        */
@@ -25625,7 +25625,7 @@ declare module "sap/ui/core/mvc/Controller" {
      * If no view is connected or if the view doesn't contain an element with the given local ID, undefined
      * is returned.
      */
-    byId<T = UI5Element>(
+    byId<T extends UI5Element = UI5Element>(
       /**
        * View-local ID
        */
@@ -25692,7 +25692,7 @@ declare module "sap/ui/core/mvc/Controller" {
      * If there is no Component connected to the view or the view is not connected to the controller, undefined
      * is returned.
      */
-    getOwnerComponent<T = Component>(): T;
+    getOwnerComponent<T extends Component = Component>(): T;
     /**
      * Returns the view associated with this controller or undefined.
      */
@@ -41851,7 +41851,7 @@ declare module "sap/ui/model/Context" {
      * Gets the (model dependent) object the context points to or the object with the given relative binding
      * path
      */
-    getObject<T = object>(
+    getObject<T extends object = object>(
       /**
        * the binding path
        */


### PR DESCRIPTION
Hey there, 

this PR is a POC for my proposal for a better API for ui5 with typescript.

I scimmed the project and my eyes often stucked on `as X` type-casts. The more typescript way is using a generic method for giving the user the possibility of defining what the method will return.

This will make calls like
```
(this.byId("submitButton") as Button).setText(this.oBundle.getText("updateButtonText"));
```
can be written as
```
this.byId<Button>("submitButton").setText(this.oBundle.getText("updateButtonText"));
```

This looks cleaner, is more readable and the programmer can get rid of the brackets around the typecast.
It also will depict the ui5 api in a better way, because of it IS indeed generic in these types of functions I touched in this PR.

@vobu 🎉