### PR TITLE
Add CI workflow and Dependabot auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Start server and verify it responds
         run: |
-          cleanup() { kill "$SERVER_PID" 2>/dev/null; }
+          cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
           trap cleanup EXIT
           npm run start &
           SERVER_PID=$!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,21 @@ jobs:
 
       - name: Start server and verify it responds
         run: |
+          cleanup() { kill "$SERVER_PID" 2>/dev/null; }
+          trap cleanup EXIT
           npm run start &
           SERVER_PID=$!
-          # Wait for the server to be ready
+          # Wait for the server to be ready (max 60s)
           for i in $(seq 1 30); do
             if curl -sf http://localhost:4004/ > /dev/null 2>&1; then
               echo "Server is up"
               break
             fi
+            if [ "$i" -eq 30 ]; then
+              echo "Server failed to start within 60s"
+              exit 1
+            fi
             sleep 2
           done
           # Verify the server responds
           curl -sf http://localhost:4004/ > /dev/null
-          # Stop the server
-          kill $SERVER_PID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Build native addons (better-sqlite3)
+        run: npm rebuild better-sqlite3
+
       - name: Lint lockfile
         run: npm run lint:lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Build native addons (better-sqlite3)
-        run: npm rebuild better-sqlite3
+        run: npm rebuild better-sqlite3 --ignore-scripts=false
 
       - name: Lint lockfile
         run: npm run lint:lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint lockfile
+        run: npm run lint:lockfile
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Start server and verify it responds
+        run: |
+          npm run start &
+          SERVER_PID=$!
+          # Wait for the server to be ready
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:4004/ > /dev/null 2>&1; then
+              echo "Server is up"
+              break
+            fi
+            sleep 2
+          done
+          # Verify the server responds
+          curl -sf http://localhost:4004/ > /dev/null
+          # Stop the server
+          kill $SERVER_PID

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 name: Dependabot auto-merge
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 name: Dependabot auto-merge
 
-on: pull_request_target
+on: pull_request
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,37 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      - name: Approve PR
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- **CI workflow** (): install → lint lockfile → build → smoke-test server start/stop
- **Dependabot auto-merge** (): auto-approve + auto-merge patch and minor updates (majors require manual review)

## Details

- All actions SHA-pinned (checkout v4.3.1, setup-node v4.4.0, fetch-metadata v2.5.0)
- Explicit `permissions: contents: read` on CI
- Auto-merge uses `gh pr merge --auto --squash` which waits for required status checks

## Prerequisites to activate auto-merge

1. Enable branch protection on `main` with the `CI` check required
2. Enable "Allow auto-merge" in repo settings (Settings → General → Pull Requests)

Without these, Dependabot PRs will still be approved automatically but won't merge until a human clicks merge.